### PR TITLE
Updated Cloudflare usage instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,12 @@ Namecheap:
 
 Cloudflare:
 
-- `"zone_identifier"`
-- `"identifier"`
+- `"zone_identifier"` is the Zone ID of your site
+- `"identifier"` is the DNS record identifier as returned by the Cloudflare "List DNS Records" API (see below)
 - `"host"` is your host and can be a subdomain, `"@"` or `"*"` generally
 - `"ttl"` integer value for record TTL in seconds (specify 1 for automatic)
 - One of the following:
-    - Email `"email"` and key `"key"`
+    - Email `"email"` and Global API Key `"key"`
     - User service key `"user_service_key"`
     - API Token `"token"`, configured with DNS edit permissions for your DNS name's zone.
 - *Optionally*, `"proxied"` can be `true` or `false` to use the proxy services of Cloudflare


### PR DESCRIPTION
I had a hard time figuring out which keys and identifiers I had to use with Cloudflare. One of the main problems was the dns record identifier. Obviously I was not smart enough to scroll down to the bottom of the page. There I would have found the missing piece of the puzzle, the Cloudflare "List DNS Records" API.
I slightly updated the README.md to make it easier for further users. Feel free to adopt the changes in case you like it.